### PR TITLE
Multiple changes

### DIFF
--- a/Deltarune.asl
+++ b/Deltarune.asl
@@ -110,6 +110,7 @@ startup
 {
     vars.tempVar = 0;
     vars.forceSplit = false;
+    vars.SPEndingTriggered = false; // Used to prevent a double split
     vars.ACContinueRooms = new[,]
     {
         {null, null},
@@ -127,6 +128,7 @@ startup
     {
         vars.tempVar = 0;
         vars.forceSplit = false;
+        vars.SPEndingTriggered = false;
         print("[DELTARUNE] All variables have been reset to initial state");
     });
 
@@ -480,7 +482,13 @@ update
         {
             case 1:
                 if(version == "SURVEY_PROGRAM")
-                    endCondition = ((((old.finalTextboxHalt == 2 && current.finalTextboxHalt != 2 || old.finalTextboxHalt2 == 2 && current.finalTextboxHalt2 != 2) && current.choicer == 0) || current.file == old.file + 3) && current.plot == 251);
+                {
+                    if(vars.SPEndingTriggered == false && (((old.finalTextboxHalt == 2 && current.finalTextboxHalt != 2 || old.finalTextboxHalt2 == 2 && current.finalTextboxHalt2 != 2) && current.choicer == 0) || current.file == old.file + 3) && current.plot == 251)
+                    {
+                        endCondition = true;
+                        vars.SPEndingTriggered = true;
+                    }
+                }
                 else
                     endCondition = ((old.text == @"＊ (ねむることにした)/%" || old.text == @"* (You decided to go to bed.)/%") && current.text == null);
                 break;

--- a/Deltarune.asl
+++ b/Deltarune.asl
@@ -251,7 +251,6 @@ exit
 init
 {
     var module = modules.First();
-    int mms = module.ModuleMemorySize;
     vars.x64 = game.Is64Bit();
 
     // Thanks to Jujstme and Ero for this (finding room names)
@@ -292,28 +291,41 @@ init
     using(var md5 = System.Security.Cryptography.MD5.Create())
         using(var fs = File.OpenRead(new FileInfo(module.FileName).DirectoryName + @"\data.win")) 
             hash = string.Concat(md5.ComputeHash(fs).Select(b => b.ToString("X2")));
-    switch(mms)
+    switch(hash)
     {
-        case 7954432:
+        case "A88A2DB3A68C714CA2B1FF57AC08A032": // English
+        case "22008370824A37BAEF8948127963C769": // Japanese
             version = "SURVEY_PROGRAM";
             break;
 
-        case 7495680:
-            if(hash != "5FBE01F2BC1C04F45D809FFD060AC386")
-                version = "Demo v1.08/v1.09";
-            else
-                version = "Demo v1.10";
+        case "B465A74B67E4AB915856330AD1149A62": // v1.08 (itch.io)
+        case "AFA40591602758CC56F445E819023E76": // v1.08 (Steam)
+        case "616C5751AC9FC584AF250F1B04474AFD": // v1.09 (itch.io)
+        case "267A8ABE468D824222810201F00003BE": // v1.09 (Steam)
+            version = "Demo v1.08/v1.09";
             break;
 
-        case 7503872:
+        case "5FBE01F2BC1C04F45D809FFD060AC386": // itch.io
+        case "CD77A63D7902990DBC704FE32B30700A": // Steam
+            version = "Demo v1.10";
+            break;
+
+        case "7FA7658151211076FA09BE378BD6BD2B": // v1.12
+        case "D64C80F30EC1AA5718307A2C6EA8DDB5": // v1.13
+        case "8892ACA0ECE33A17711D7780C70CA3DE": // v1.14
+        case "ED4568BAB864166BFD6322CEEB3FB544": // v1.15
             version = "Demo v1.12-v1.15";
             break;
 
-        case 9650176:
-            if(hash != "7AD299A8B33FA449E20EDFE0FEDEDDB2")
-                version = "Demo v1.16/v1.17";
-            else
-                version = "Demo v1.19";
+        // game_change versions - Only check the Chapter Select data.win
+        // Checks for the individual chapters could also be added but there's no point
+        case "498FA77370216BCA0447416A49F34BEF": // v1.16
+        case "6A68061F85445AD705FA200166EEC39F": // v1.17
+            version = "Demo v1.16/v1.17";
+            break;
+            
+        case "7AD299A8B33FA449E20EDFE0FEDEDDB2":
+            version = "Demo v1.19";
             break;
 
         default:
@@ -321,13 +333,18 @@ init
 
             MessageBox.Show
             (
-                "This version of DELTARUNE is not supported by the autosplitter.\nIf you are playing an older version, update your game.\nIf not, please wait until the autosplitter receives an update.\n\n" +
+                "This version of DELTARUNE is not supported by the autosplitter.\n" +
+                "If you are playing an older version, update your game.\n" +
+                "If you are playing a mod, switch to the vanilla game.\n\n" +
+
+                "Make sure the game's executable is named \"DELTARUNE.exe\" and the data file is named \"data.win\".\n\n" +
+
                 "Supported versions: SURVEY_PROGRAM, Chapter 1&2 v1.08-v1.19.",
                 "LiveSplit | DELTARUNE", MessageBoxButtons.OK, MessageBoxIcon.Warning
             );
             break;
     }
-    print("[DELTARUNE] Detected game version: " + version + " (" + mms + " / " + hash + ")");
+    print("[DELTARUNE] Detected game version: " + version + " (" + hash + ")");
 
     // Ending splits are handled manually in update{}
     // Object variables in order: done, old room, new room, old fight, new fight, special condition

--- a/Deltarune.asl
+++ b/Deltarune.asl
@@ -3,6 +3,7 @@
 state("DELTARUNE", "SURVEY_PROGRAM")
 {
     // Global
+    double file    : 0x48E5DC, 0x27C, 0x488, 0x4D0; // global.filechoice
     double plot    : 0x48E5DC, 0x27C, 0x488, 0x500; // global.plot
     double choicer : 0x48E5DC, 0x27C, 0x28,  0x40;  // global.choice
 
@@ -107,7 +108,6 @@ state("DELTARUNE", "Demo v1.19")
 
 startup
 {
-    refreshRate = 30;
     vars.tempVar = 0;
     vars.forceSplit = false;
     vars.ACContinueRooms = new[,]
@@ -480,7 +480,7 @@ update
         {
             case 1:
                 if(version == "SURVEY_PROGRAM")
-                    endCondition = (((old.finalTextboxHalt == 2 && current.finalTextboxHalt != 2) || (old.finalTextboxHalt2 == 2 && current.finalTextboxHalt2 != 2)) && current.choicer == 0 && current.plot == 251);
+                    endCondition = ((((old.finalTextboxHalt == 2 && current.finalTextboxHalt != 2 || old.finalTextboxHalt2 == 2 && current.finalTextboxHalt2 != 2) && current.choicer == 0) || current.file == old.file + 3) && current.plot == 251);
                 else
                     endCondition = ((old.text == @"＊ (ねむることにした)/%" || old.text == @"* (You decided to go to bed.)/%") && current.text == null);
                 break;

--- a/Deltarune.asl
+++ b/Deltarune.asl
@@ -334,6 +334,7 @@ init
 
         default:
             version = "Unknown";
+            print("[DELTARUNE] Unknown version detected: " + hash);
 
             MessageBox.Show
             (
@@ -346,8 +347,6 @@ init
                 "Supported versions: SURVEY_PROGRAM, Chapter 1&2 v1.08-v1.19.",
                 "LiveSplit | DELTARUNE", MessageBoxButtons.OK, MessageBoxIcon.Warning
             );
-
-            print("[DELTARUNE] Unknown version detected: " + hash);
             return;
     }
     print("[DELTARUNE] Detected game version: " + version + " (" + hash + ")");

--- a/Deltarune.asl
+++ b/Deltarune.asl
@@ -342,7 +342,9 @@ init
                 "Supported versions: SURVEY_PROGRAM, Chapter 1&2 v1.08-v1.19.",
                 "LiveSplit | DELTARUNE", MessageBoxButtons.OK, MessageBoxIcon.Warning
             );
-            break;
+
+            print("[DELTARUNE] Unknown version detected: " + hash);
+            return;
     }
     print("[DELTARUNE] Detected game version: " + version + " (" + hash + ")");
 

--- a/Deltarune.asl
+++ b/Deltarune.asl
@@ -287,10 +287,14 @@ init
         return game.ReadString(arrayItem, 64);
     });
 
-    string hash;
-    using(var md5 = System.Security.Cryptography.MD5.Create())
-        using(var fs = File.OpenRead(new FileInfo(module.FileName).DirectoryName + @"\data.win")) 
-            hash = string.Concat(md5.ComputeHash(fs).Select(b => b.ToString("X2")));
+    string hash = "\0";
+    string dataFile = new FileInfo(module.FileName).DirectoryName + @"\data.win";
+    if(File.Exists(dataFile))
+    {
+        using(var md5 = System.Security.Cryptography.MD5.Create())
+            using(var fs = File.OpenRead(new FileInfo(module.FileName).DirectoryName + @"\data.win"))
+                hash = string.Concat(md5.ComputeHash(fs).Select(b => b.ToString("X2")));
+    }
     switch(hash)
     {
         case "A88A2DB3A68C714CA2B1FF57AC08A032": // English

--- a/Deltarune.asl
+++ b/Deltarune.asl
@@ -292,7 +292,7 @@ init
     if(File.Exists(dataFile))
     {
         using(var md5 = System.Security.Cryptography.MD5.Create())
-            using(var fs = File.OpenRead(new FileInfo(module.FileName).DirectoryName + @"\data.win"))
+            using(var fs = File.OpenRead(dataFile))
                 hash = string.Concat(md5.ComputeHash(fs).Select(b => b.ToString("X2")));
     }
     switch(hash)

--- a/cspell.json
+++ b/cspell.json
@@ -34,6 +34,7 @@
         "DELTARUNE",
         "endregion",
         "fightsusie",
+        "filechoice",
         "Forcefield",
         "Giga",
         "Glacia",


### PR DESCRIPTION
- Version detection moved entirely to data.win hash
- Autosplitter now entirely stops at init if an unknown version is detected
- Clearer unsupported version message
- Added a backup SURVEY_PROGRAM end split (after closing the textbox, one frame after the normal split point in case it fails) (had to remove the 30hz refresh rate for this because the global.filechoice change wouldn't always be detected properly)