### PR TITLE
Release 2.6.2 - Version detection changes

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -34,6 +34,7 @@
         "DELTARUNE",
         "endregion",
         "fightsusie",
+        "filechoice",
         "Forcefield",
         "Giga",
         "Glacia",


### PR DESCRIPTION
- Version detection moved entirely to data.win hash
- Autosplitter now entirely stops at init if an unknown version is detected
- Clearer unsupported version message
- Added a backup SURVEY_PROGRAM end split (after closing the textbox, one frame after the normal split point in case it fails) (had to remove the 30hz refresh rate for this because the global.filechoice change wouldn't always be detected properly)