### PR TITLE
Making OST% timer pause account for Until Next Time being shared between Chapters 2 and 3

### DIFF
--- a/Deltarune.asl
+++ b/Deltarune.asl
@@ -781,7 +781,7 @@ update
 
         if(endCondition)
         {
-            if(settings["AC_PauseTimer"] && (!settings["AC_PauseTimerOST"] || (current.chapter == 2 && settings["AC_AlternateCh2") || (current.chapter == 3 && !settings["AC_AlternateCh2"])) && !timer.IsGameTimePaused)
+            if(settings["AC_PauseTimer"] && (!settings["AC_PauseTimerOST"] || (current.chapter == 2 && settings["AC_AlternateCh2"]) || (current.chapter == 3 && !settings["AC_AlternateCh2"])) && !timer.IsGameTimePaused)
             {
                 print("[DELTARUNE] All Chapters: Chapter " + ch + " ended, timer paused");
                 timer.IsGameTimePaused = true;

--- a/Deltarune.asl
+++ b/Deltarune.asl
@@ -781,7 +781,7 @@ update
 
         if(endCondition)
         {
-            if(settings["AC_PauseTimer"] && !settings["AC_PauseTimerOST"] && !timer.IsGameTimePaused)
+            if(settings["AC_PauseTimer"] && (!settings["AC_PauseTimerOST"] || (current.chapter == 2 && settings["AC_AlternateCh2") || (current.chapter == 3 && !settings["AC_AlternateCh2"])) && !timer.IsGameTimePaused)
             {
                 print("[DELTARUNE] All Chapters: Chapter " + ch + " ended, timer paused");
                 timer.IsGameTimePaused = true;


### PR DESCRIPTION
OST% version of All Chapters IGT pause should now only apply OST% timing rules to one of Chapters 2 and 3, depending on the Chapter 2 pause timing setting, since Chapters 2 and 3 share the same credits theme