### PR TITLE
Update README with autosplitter usage recommendation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ or clone the repository
 
 > The autosplitter file will auto-refresh when you save it.
 
+> This is also the recommended way to use the everyroom autosplitters
+
 ## How to use
 
 To use and configure the autosplitter, just click `Settings` and enable the locations you want the autosplitter


### PR DESCRIPTION
I updated the Readme to mention the fact that using the scriptable autosplitter component in your layout is the recommended way to use the everyroom autosplitters.