### PR TITLE
Single line addition to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ or clone the repository
 
 > The autosplitter file will auto-refresh when you save it.
 
+> This is also the recommended way to use the everyroom autosplitters
+
 ## How to use
 
 To use and configure the autosplitter, just click `Settings` and enable the locations you want the autosplitter

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ or clone the repository
 
 > The autosplitter file will auto-refresh when you save it.
 
-> This is also the recommended way to use the everyroom autosplitters
+> This is also the recommended way to use the everyroom autosplitters.
 
 ## How to use
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ or clone the repository
 > The autosplitter file will auto-refresh when you save it.
 
 > This is also the recommended way to use the every room autosplitter.
+
 ## How to use
 
 To use and configure the autosplitter, just click `Settings` and enable the locations you want the autosplitter

--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ or clone the repository
 > The autosplitter file will auto-refresh when you save it.
 
 > This is also the recommended way to use the every room autosplitter.
-
 ## How to use
 
 To use and configure the autosplitter, just click `Settings` and enable the locations you want the autosplitter

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ or clone the repository
 
 > The autosplitter file will auto-refresh when you save it.
 
-> This is also the recommended way to use the everyroom autosplitters.
+> This is also the recommended way to use the every room autosplitter.
 
 ## How to use
 


### PR DESCRIPTION
I added a single line to the README to reference the fact that setting up the everyroom autosplitters in the livesplit layout is the recommended way to use them.

I'm a github noob so if these checks don't pass so be it